### PR TITLE
NEXUS-36743 Nexus HA EBS storage class should use the EBS CSI Storage Provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ HA requires the following:
 * A Nexus Repository 3 Pro license
 * An external PostgreSQL database using Postgres 13 or later; size your database appropriately based on your request traffic and desired number of nodes
 * At least 2 Nexus Repository instances
-    * All Nexus Repository instances must be using the same Nexus Repository 3 Pro version, and it must be version 3.44.0 or later
+    * All Nexus Repository instances must be using the same Nexus Repository 3 Pro version, and it must be version 3.45.1 or later
     * All Nexus Repository instances must have identical configuration in their $data-dir/etc/nexus.properties files
 * A load balancer (e.g., HAProxy, NGINX, Apache HTTP, or AWS ELB)
 * A blob store location for storing components that can be commonly accessed by all active nodes

--- a/nxrm-aws-ha-helm/Chart.yaml
+++ b/nxrm-aws-ha-helm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 45.0.0
+version: 45.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/nxrm-aws-ha-helm/Chart.yaml
+++ b/nxrm-aws-ha-helm/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 43.0.0
+version: 45.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 3.43.0
+appVersion: 3.45.1
 
 keywords:
   - artifacts

--- a/nxrm-aws-ha-helm/templates/statefulset.yaml
+++ b/nxrm-aws-ha-helm/templates/statefulset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Chart.Name }}-{{ .Chart.Version  | replace "." "-"}}-{{ .Release.Name }}-{{ .Values.statefulset.name }}
+  name: {{ .Chart.Name }}-{{ .Chart.Version  | replace "." "-"}}-{{ .Values.statefulset.name }}
   namespace: {{ .Values.namespaces.nexusNs }}
   labels:
     app: nxrm

--- a/nxrm-aws-ha-helm/templates/storageclass.yaml
+++ b/nxrm-aws-ha-helm/templates/storageclass.yaml
@@ -3,7 +3,7 @@ kind: StorageClass
 metadata:
   name: "{{ .Chart.Name }}-{{ .Chart.Version}}-{{ .Release.Name }}-ebs-storage"
   namespace: {{ .Values.namespaces.nexusNs }}
-provisioner: kubernetes.io/aws-ebs
+provisioner: {{ .Values.storageClass.provisioner }}
 parameters:
   type: io1
   fsType: "ext4"

--- a/nxrm-aws-ha-helm/values.yaml
+++ b/nxrm-aws-ha-helm/values.yaml
@@ -19,7 +19,7 @@ statefulset:
   container:
     image:
       repository: sonatype/nexus3
-      tag: 3.44.0
+      tag: 3.45.1
     containerPort: 8081
     pullPolicy: IfNotPresent
     env:

--- a/nxrm-aws-ha-helm/values.yaml
+++ b/nxrm-aws-ha-helm/values.yaml
@@ -61,7 +61,7 @@ ingress:
       alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:0000000000000:certificate/00000000-1111-2222-3333-444444444444  # Comment out if you don't use docker repositories - The AWS Certificate Manager ARN for your HTTPS certificate
       external-dns.alpha.kubernetes.io/hostname: dockerrepo1.example.com, dockerrepo2.example.com, dockerrepo3.example.com # Add more docker subdomains using dockerrepoName.example.com otherwise comment out if you don't use docker repositories
 storageClass:
-  provisioner: kubernetes.io/aws-ebs # in case of AWS EKS cluster running version 1.23 or later use 'ebs.csi.aws.com'
+  provisioner: ebs.csi.aws.com # in case of AWS EKS cluster running version less than 1.23 use 'kubernetes.io/aws-ebs'
   zones:
     zone1: zone1
     zone2: zone2

--- a/nxrm-aws-ha-helm/values.yaml
+++ b/nxrm-aws-ha-helm/values.yaml
@@ -61,6 +61,7 @@ ingress:
       alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:0000000000000:certificate/00000000-1111-2222-3333-444444444444  # Comment out if you don't use docker repositories - The AWS Certificate Manager ARN for your HTTPS certificate
       external-dns.alpha.kubernetes.io/hostname: dockerrepo1.example.com, dockerrepo2.example.com, dockerrepo3.example.com # Add more docker subdomains using dockerrepoName.example.com otherwise comment out if you don't use docker repositories
 storageClass:
+  provisioner: kubernetes.io/aws-ebs # in case of AWS EKS cluster running version 1.23 or later use 'ebs.csi.aws.com'
   zones:
     zone1: zone1
     zone2: zone2

--- a/sample-aws-ha-yamls/aws-ha-statefulset.yaml
+++ b/sample-aws-ha-yamls/aws-ha-statefulset.yaml
@@ -45,7 +45,7 @@ spec:
       terminationGracePeriodSeconds: 20
       containers:
         - name: nxrm-app
-          image: sonatype/nexus3:3.44.0
+          image: sonatype/nexus3:3.45.1
           securityContext:
             runAsUser: 200
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
**Description:**
users of EKS version 1.23 should use `ebs.csi.aws.com` while users of EKS version less than 1.23 should use `kubernetes.io/aws-ebs`